### PR TITLE
Feature: Add ability to submit and view responses to questions

### DIFF
--- a/API/Controllers/QuestionController.cs
+++ b/API/Controllers/QuestionController.cs
@@ -1,7 +1,10 @@
-﻿using InterviewMinuteAPI.Model;
+﻿using Azure;
+using InterviewMinuteAPI.Model;
 using InterviewMinuteAPI.Repository;
 using InterviewMinuteAPI.Service.Interface;
 using Microsoft.AspNetCore.Mvc;
+using System.Data;
+using System.Data.SqlClient;
 
 namespace InterviewMinuteAPI.Controllers
 {
@@ -45,6 +48,58 @@ namespace InterviewMinuteAPI.Controllers
             {
                 return StatusCode(500, e.Message);
             }
+        }
+
+        [HttpGet("add-response")]
+        public IActionResult AddResponse([FromQuery] int questionId, [FromQuery] int answerId)
+        {
+            var connection = new SqlConnection((new ConfigurationBuilder().AddJsonFile("appsettings.json").AddEnvironmentVariables().Build()).GetConnectionString("InterviewMinute"));
+            connection.Open();
+            var cmd = new SqlCommand("dbo.InsertResponse", connection); //SqlCommand("INSERT INTO dbo.Response (Question,Answer,WhenDidTheResponseHappenAt) VALUES (1,1,'2021-09-01 00:00:00.000')");
+            cmd.Parameters.AddWithValue("@Question", questionId);
+            cmd.Parameters.AddWithValue("@Answer", answerId);
+            cmd.Parameters.AddWithValue("@ResponseTime", DateTime.Now);
+            cmd.CommandType = (CommandType)4;
+            var reader = cmd.ExecuteReader();
+            return Ok();
+        }
+
+        [HttpGet("get-responses-route")]
+        public IActionResult GetResponses()
+        {
+            List<object> responses = new List<object>();
+
+            try
+            {
+                IConfiguration configuration = new ConfigurationBuilder()
+        .AddJsonFile("appsettings.json")
+        .AddEnvironmentVariables()
+        .Build();
+                var c = configuration.GetConnectionString("InterviewMinute");
+                var c2 = new SqlConnection(c);
+                c2.Open();
+                var cmd = new SqlCommand("dbo.GetResponses", c2);
+                cmd.CommandType = (CommandType)4;
+                var reader = cmd.ExecuteReader();
+                responses = new List<object>();
+                while (true)
+                {
+                    if (!reader.Read())
+                    {
+                        break;
+                    }
+                    responses.Add(new
+                    {
+                        Question = reader["qtext"],
+                        Answer = reader["Answer"],
+                        ResponseTime = reader["WhenDidTheResponseHappenAt"]
+                    });
+                }
+            }
+            catch (Exception e)
+            {
+            }
+            return Ok(responses);
         }
     }
 }

--- a/API/InterviewMinuteAPI.csproj
+++ b/API/InterviewMinuteAPI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -13,6 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
 
 </Project>

--- a/DB/InterviewMinute.sqlproj
+++ b/DB/InterviewMinute.sqlproj
@@ -58,9 +58,13 @@
     <Folder Include="Properties" />
     <Folder Include="dbo\" />
     <Folder Include="dbo\Tables\" />
+    <Folder Include="dbo\Stored Procedures\" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="dbo\Tables\Question.sql" />
     <Build Include="dbo\Tables\Answer.sql" />
+    <Build Include="dbo\Tables\Response.sql" />
+    <Build Include="dbo\Stored Procedures\InsertResponse.sql" />
+    <Build Include="dbo\Stored Procedures\GetResponses.sql" />
   </ItemGroup>
 </Project>

--- a/DB/dbo/Stored Procedures/GetResponses.sql
+++ b/DB/dbo/Stored Procedures/GetResponses.sql
@@ -1,0 +1,22 @@
+﻿CREATE PROCEDURE dbo.GetResponses
+AS
+BEGIN
+    SELECT Question.Text AS qtext,
+           QuestionId AS qid
+    INTO #Questions
+    FROM dbo.Question
+    WHERE QuestionId IN
+          (
+              SELECT Question FROM dbo.Response
+          );
+
+    SELECT *
+    FROM #Questions
+        JOIN dbo.Response
+            ON qid = Question;
+
+    IF OBJECT_ID('tempdb..#Questions') IS NOT NULL
+    BEGIN
+        DROP TABLE #Questions;
+    END;
+END;

--- a/DB/dbo/Stored Procedures/InsertResponse.sql
+++ b/DB/dbo/Stored Procedures/InsertResponse.sql
@@ -1,0 +1,24 @@
+﻿CREATE PROCEDURE dbo.InsertResponse
+    @ResponseTime DATETIME,
+    @Answer BIGINT,
+    @Question BIGINT
+AS
+BEGIN
+    DECLARE @AnswerForResponse NVARCHAR(MAX);
+    SELECT @AnswerForResponse = Text
+    FROM dbo.Answer
+    WHERE @Answer = AnswerId
+          AND @Question = QuestionId;
+
+    INSERT INTO dbo.Response
+    (
+        Question,
+        Answer,
+        WhenDidTheResponseHappenAt
+    )
+    VALUES
+    (   @Question,          -- Question - bigint
+        @AnswerForResponse, -- Answer - nvarchar(150)
+        @ResponseTime       -- WhenDidTheResponseHappenAt - datetime
+        );
+END;

--- a/DB/dbo/Tables/Response.sql
+++ b/DB/dbo/Tables/Response.sql
@@ -1,0 +1,6 @@
+﻿CREATE TABLE [dbo].[Response] (
+    [Question]                   BIGINT         NULL,
+    [Answer]                     NVARCHAR (150) NULL,
+    [WhenDidTheResponseHappenAt] DATETIME       NULL
+);
+

--- a/UI/api.ts
+++ b/UI/api.ts
@@ -10,6 +10,11 @@ const makeRequest = async (route: string, method: string, body?: any) => {
         },
         body: body ? JSON.stringify(body) : undefined,
     })
+
+    if (response.status === 204) {
+        return
+    }
+
     return await response.json()
 }
 

--- a/UI/app/index.tsx
+++ b/UI/app/index.tsx
@@ -13,6 +13,9 @@ export default function Index() {
             <Link href="/question">
                 <Text>Click here to get a random question.</Text>
             </Link>
+            <Link href="/responses">
+                <Text>Click here to view responses.</Text>
+            </Link>
         </View>
     )
 }

--- a/UI/app/question.tsx
+++ b/UI/app/question.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import {Link} from 'expo-router'
-import {StyleSheet, Text, View} from 'react-native'
+import React, {useState} from 'react'
+import {Link, router} from 'expo-router'
+import {Button, StyleSheet, Text, View, TouchableOpacity} from 'react-native'
 import useQuestion, {Answer} from '@/hooks/useQuestion'
 
 const styles = StyleSheet.create({
@@ -35,8 +35,9 @@ const styles = StyleSheet.create({
 })
 
 export default function Index() {
-    const {question, loading} = useQuestion()
+    const {question, loading, submitResponse} = useQuestion()
     const sortedAnswers = question?.answers.sort((a, b) => a.displayOrder - b.displayOrder)
+    const [selectedAnswer, setAnswer] = useState('')
     return (
         <View style={styles.container}>
             {loading && <Text>Loading...</Text>}
@@ -47,11 +48,38 @@ export default function Index() {
                         <Text>{question.text}</Text>
                     </View>
                     <View style={styles.questionSeparator} />
-                    {sortedAnswers?.map((answer: Answer) => (
-                        <View key={answer.answerId} style={styles.answerContainer}>
-                            <Text>{answer.text}</Text>
-                        </View>
-                    ))}
+                    {sortedAnswers?.map((answer: Answer) => {
+                        const styleToUse =
+                            answer.text == selectedAnswer
+                                ? [
+                                      styles.answerContainer,
+                                      {borderColor: '#000000', borderStyle: 'solid', borderWidth: 2},
+                                  ]
+                                : styles.answerContainer
+                        return (
+                            <TouchableOpacity
+                                key={answer.answerId}
+                                style={styleToUse}
+                                onPress={() => {
+                                    setAnswer(answer.text)
+                                }}
+                            >
+                                <Text>{answer.text}</Text>
+                            </TouchableOpacity>
+                        )
+                    })}
+                    <Button
+                        title="Submit"
+                        onPress={() => {
+                            let answerId = sortedAnswers?.find(
+                                (answer: Answer) => answer.text == selectedAnswer,
+                            )?.answerId
+                            if (answerId) {
+                                submitResponse(answerId, question.questionId)
+                            }
+                            router.push('/')
+                        }}
+                    />
                 </>
             )}
             <Link href="/">

--- a/UI/app/responses.js
+++ b/UI/app/responses.js
@@ -1,0 +1,46 @@
+import {Link} from 'expo-router'
+import {useEffect, useState} from 'react'
+import {Text, View, ScrollView} from 'react-native'
+import {fetch} from 'expo/fetch'
+
+export default function Index() {
+    const [responses, setResponses] = useState([])
+    useEffect(() => {
+        fetch('https://localhost:7163/questions/get-responses-route').then((response) => {
+            response.json().then((data) => {
+                setResponses(data)
+            })
+        })
+    }, [])
+
+    var questionResponse = responses[0]
+
+    return (
+        <ScrollView
+            style={{
+                flex: 1,
+            }}
+        >
+            <View style={{width: '100%', alignItems: 'center', marginVertical: 20}}>
+                {questionResponse &&
+                    responses.map((response, index) => (
+                        <View
+                            key={index}
+                            style={{
+                                marginBottom: 20,
+                                backgroundColor: 'lightgray',
+                                padding: 10,
+                                width: 700,
+                            }}
+                        >
+                            <Text style={{fontWeight: 'bold'}}>Question:</Text>
+                            <Text>{questionResponse.question}</Text>
+                            <Text style={{fontWeight: 'bold'}}>Your Answer:</Text>
+                            <Text>{response.answer}</Text>
+                        </View>
+                    ))}
+                <Link href="/">Back to Home</Link>
+            </View>
+        </ScrollView>
+    )
+}

--- a/UI/hooks/useQuestion.ts
+++ b/UI/hooks/useQuestion.ts
@@ -31,7 +31,13 @@ const useQuestion = () => {
         getRandomQuestion()
     }, [])
 
-    return {question, loading}
+    const submitResponse = async (answerId: any, questionId: any) => {
+        await makeRequest(
+            'questions/add-response?questionId=' + questionId + '&answerId=' + answerId,
+            'GET',
+        )
+    }
+    return {question, loading, submitResponse}
 }
 
 export default useQuestion


### PR DESCRIPTION
This feature enables the ability to respond to questions and to view prior responses. Responses are saved in a new [Responses] table.

On the /question page answers are now selectable and a submit button is added to submit a response.
![interview-1](https://github.com/user-attachments/assets/9c5f69d9-f9a5-4cd7-aadc-316df8b34d42)

On the root page a new link takes you to the /responses page.
![interview2](https://github.com/user-attachments/assets/b571f8a1-e34f-4551-9d0b-0367e9c9838f)


The /responses page shows previous questions and the selected answer.
![interview3](https://github.com/user-attachments/assets/5a2d4cc8-8123-4c59-b6b4-73e96ade5412)
